### PR TITLE
download.vue: remove superfluous 'v'

### DIFF
--- a/pages/download.vue
+++ b/pages/download.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
     <div class="container">
-      <h2>PicoTorrent v{{ release.version }}</h2>
+      <h2>PicoTorrent {{ release.version }}</h2>
       <p>Get the latest release, select your desired file:</p>
       <!-- Releases -->
       <h3>Releases</h3>


### PR DESCRIPTION
Fixes Download page (https://picotorrent.org/download) superfluous 'v' (version) that is already applied through `release.version`

![Screenshot_20230722_075641](https://github.com/picotorrent/website/assets/4140247/1a81e7e1-9945-4a8a-aa4c-3558bb6c07ce)
